### PR TITLE
Fixed botsfordiscord widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Gearz
-[![Discord Bots](https://discordbots.org/api/widget/367202192609902593.svg)](https://discordbots.org/bot/367202192609902593) [![Bots for discord](https://botsfordiscord.com/api/v1/bots/367202192609902593/embed?theme=dark)](https://botsfordiscord.com/bot/367202192609902593)
+[![Discord Bots](https://discordbots.org/api/widget/367202192609902593.svg)](https://discordbots.org/bot/367202192609902593) [![Bots for discord](https://botsfordiscord.com/bot/367202192609902593)](https://botsfordiscord.com/bot/367202192609902593)
 
 This bot is also listed on [Listcord](https://listcord.com/bot/367202192609902593)
 


### PR DESCRIPTION
Botsfordiscord.com updated their api so the URL of the widget/embed wasn't working anymore